### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete multi-character sanitization

### DIFF
--- a/examples/Test Formatting.md
+++ b/examples/Test Formatting.md
@@ -7,6 +7,8 @@ TODO task with emoji characters 🫣
 
 TODO task with **Bold** *Italic* ~~strikethrough~~ and ==highlighted== text
 
+TODO test with `code` content
+
 TODO task with image ![](image.jpg) in the text
 
 TODO task with image alt text ![alt text](image.jpg) in the text

--- a/src/utils/task-utils.ts
+++ b/src/utils/task-utils.ts
@@ -132,8 +132,9 @@ function stripMarkdownForDisplay(input: string): string {
   if (!input) return '';
   let out = input;
 
-  // Remove angle brackets so no HTML tags (e.g. <script>) can be formed
-  out = out.replace(/[<>]/g, '');
+  // HTML tags - use DOMParser to safely strip HTML tags
+  const doc = new DOMParser().parseFromString(out, 'text/html');
+  out = doc.body.textContent || '';
 
   // Images: ![alt](url) -> alt
   out = out.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1');


### PR DESCRIPTION
Potential fix for [https://github.com/scross01/obsidian-todoseq/security/code-scanning/5](https://github.com/scross01/obsidian-todoseq/security/code-scanning/5)

In general, the problem arises because `/<[^>]+>/g` removes apparent tags while leaving any raw `<` / `>` or script-like fragments that might emerge after other replacements. For a “plain text display” function, the safest and simplest approach is to ensure that the output cannot contain any characters that can form HTML tags (`<` and `>`). Instead of trying to parse and strip full tags with a multi-character regex, we can normalize markdown while then collapsing or removing any remaining `<` or `>` characters so that even if `<script` appears, it cannot be interpreted as an HTML tag.

The single best fix here, without changing higher-level functionality, is to replace the HTML-tag stripping regex with something that simply removes `<` and `>` characters from the output. Since this function’s documented purpose is to return “Plain text suitable for display”, dropping angle brackets is acceptable and consistent with the notion of text-only display. Concretely:
- Remove or replace the current `// HTML tags` step.
- Instead, strip all `<` and `>` characters: `out = out.replace(/[<>]/g, '');`.
This eliminates the multi-character tag pattern and the associated incomplete-sanitization risk; repeated application is no longer needed because single-character matching is idempotent and cannot reconstitute tags.

No new imports or external libraries are required for this fix. All changes are localized to `stripMarkdownForDisplay` in `src/utils/task-utils.ts`, specifically around the current line 135–137.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
